### PR TITLE
a form has access to its inputs with name

### DIFF
--- a/15 - LocalStorage/index-FINISHED.html
+++ b/15 - LocalStorage/index-FINISHED.html
@@ -32,7 +32,7 @@
 
   function addItem(e) {
     e.preventDefault();
-    const text = (this.querySelector('[name=item]')).value;
+    const text = this.item.value;
     const item = {
       text,
       done: false


### PR DESCRIPTION
another option is using this.elements['item'], since then you can't have the attribute 'item' of the form'