### PR TITLE
Use replacement pattern for case-insensitive highlights

### DIFF
--- a/06 - Type Ahead/index-FINISHED.html
+++ b/06 - Type Ahead/index-FINISHED.html
@@ -38,8 +38,8 @@ function displayMatches() {
   const matchArray = findMatches(this.value, cities);
   const html = matchArray.map(place => {
     const regex = new RegExp(this.value, 'gi');
-    const cityName = place.city.replace(regex, `<span class="hl">${this.value}</span>`);
-    const stateName = place.state.replace(regex, `<span class="hl">${this.value}</span>`);
+    const cityName = place.city.replace(regex, '<span class="hl">$&</span>');
+    const stateName = place.state.replace(regex, '<span class="hl">$&</span>');
     return `
       <li>
         <span class="name">${cityName}, ${stateName}</span>


### PR DESCRIPTION
This commit aims to improve highlighting by using a replacement pattern as described here: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)

When the user searches using a string that includes an uppercase character, **${this.value}** will insert an uppercase in the highlights - whether the matched substring included one or not. Using the **$&** replacement pattern fixes this, by inserting the originally matched (sub)string instead of the user's input string.