### PR TITLE
fix first-time checkbox bug

### DIFF
--- a/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
+++ b/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
@@ -117,12 +117,12 @@ function handleCheck(e) {
     // loop over every single checkbox
     checkboxes.forEach(checkbox => {
       console.log(checkbox);
-      if (checkbox === this || checkbox === lastChecked) {
+      if ((checkbox === this || checkbox === lastChecked) && this !== lastChecked) {
         inBetween = !inBetween;
         console.log('STarting to check them inbetween!');
       }
 
-      if (inBetween) {
+      if (inBetween && lastChecked) {
         checkbox.checked = true;
       }
     });


### PR DESCRIPTION
The current check boxes. If you Shift+check the box will check all the boxes below it since there's no `lastChecked` hence `inBetween` cannot be flipped back to true.