### PR TITLE
fixed bugs

### DIFF
--- a/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
+++ b/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
@@ -104,15 +104,15 @@
   </div>
 
 <script>
-const checkboxes = document.querySelectorAll('.inbox input[type="checkbox"]');
+var checkboxes = document.querySelectorAll('.inbox input[type="checkbox"]');
 
-let lastChecked;
+let lastChecked = 'none';
 
 function handleCheck(e) {
   // Check if they had the shift key down
   // AND check that they are checking it
   let inBetween = false;
-  if (e.shiftKey && this.checked) {
+  if (e.shiftKey && lastChecked != 'none' && this !== lastChecked) {
     // go ahead and do what we please
     // loop over every single checkbox
     checkboxes.forEach(checkbox => {
@@ -124,11 +124,21 @@ function handleCheck(e) {
 
       if (inBetween) {
         checkbox.checked = true;
+      }else{
+        if(checkbox !== this && checkbox !== lastChecked){
+          checkbox.checked = false;
+        }
       }
     });
   }
 
-  lastChecked = this;
+  if(e.shiftKey && lastChecked != 'none'){
+    return;
+  }else if(this.checked == true){
+    lastChecked = this;
+  }else{
+    lastChecked = 'none';
+  }
 }
 
 checkboxes.forEach(checkbox => checkbox.addEventListener('click', handleCheck));

--- a/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
+++ b/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
@@ -104,7 +104,7 @@
   </div>
 
 <script>
-var checkboxes = document.querySelectorAll('.inbox input[type="checkbox"]');
+const checkboxes = document.querySelectorAll('.inbox input[type="checkbox"]');
 
 let lastChecked = 'none';
 


### PR DESCRIPTION
fix #1: shift click a checkbox only check itself instead of checking the rest of the checkboxes if there wasn't a last checkbox already
fix #2: unchecking a checkbox doesn't assign the checkbox to the lastChecked variable
fix #3: when selecting multiple checkboxes in the opposite direction of the last multiple checkboxes selection, the new selection is made from the lastCheckbox variable of the previous selection instead of the current selection. (e.g: selecting checkbox5 and selecting checkbox9 will select checkbox5,6,7,8,9, after that selecting checkbox1 will only select checkbox1,2,3,4,5 and uncheck 6,7,8,9 instead of checking 1 all the way to 9.)
fix #4: shift-click on an already checked checkbox uncheck the checkbox instead checking the rest of the checkboxes