### PR TITLE
rely on Javascript's toLocaleString() to supply the commas

### DIFF
--- a/06 - Type Ahead/index-FINISHED.html
+++ b/06 - Type Ahead/index-FINISHED.html
@@ -43,7 +43,7 @@ function displayMatches() {
     return `
       <li>
         <span class="name">${cityName}, ${stateName}</span>
-        <span class="population">${numberWithCommas(place.population)}</span>
+        <span class="population">${parseInt(place.population).toLocaleString()}</span>
       </li>
     `;
   }).join('');


### PR DESCRIPTION
I was thinking that it might be better to use Javascript's toLocaleString() to supply the commas or periods or whatever your used to for large numbers.  I'm not sure if this is the best way to use it here, but it works just fine.

Please let me know if I can write this better.  Thanks!