### PR TITLE
Adding fix for 'sticky' play class

### DIFF
--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -58,6 +58,11 @@
   <audio data-key="76" src="sounds/tink.wav"></audio>
 
 <script>
+
+  function hasClass(element, cls) {
+      return (' ' + element.className + ' ').indexOf(' ' + cls + ' ') > -1;
+  }
+
   function removeTransition(e) {
     if (e.propertyName !== 'transform') return;
     e.target.classList.remove('playing');
@@ -67,8 +72,9 @@
     const audio = document.querySelector(`audio[data-key="${e.keyCode}"]`);
     const key = document.querySelector(`div[data-key="${e.keyCode}"]`);
     if (!audio) return;
-
-    key.classList.add('playing');
+    if (!hasClass(key,'playing')){
+      key.classList.add('playing');
+    }
     audio.currentTime = 0;
     audio.play();
   }


### PR DESCRIPTION
I noticed the ‘playing’ class would remain applied if the key is held
down.
This fix just checks to see if the element already has the class and
only applies it if not.