### PR TITLE
Ex10 - unchecked bugfix

### DIFF
--- a/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
+++ b/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
@@ -112,7 +112,7 @@ function handleCheck(e) {
   // Check if they had the shift key down
   // AND check that they are checking it
   let inBetween = false;
-  if (e.shiftKey && this.checked) {
+  if (e.shiftKey && this.checked && lastChecked) {
     // go ahead and do what we please
     // loop over every single checkbox
     checkboxes.forEach(checkbox => {
@@ -128,7 +128,12 @@ function handleCheck(e) {
     });
   }
 
-  lastChecked = this;
+  if (this.checked) {
+    lastChecked = this;
+  } else {
+    lastChecked = null;
+  }
+
 }
 
 checkboxes.forEach(checkbox => checkbox.addEventListener('click', handleCheck));


### PR DESCRIPTION
Fixes a bug that would cause checkboxes "in between" to be checked even if the last check box was unchecked.
Example : 
Check then uncheck the first checkbox. Hold shift, and check the last checkbox. All the checkboxes are checked, when only the last one should be checked.

This could still be improved: For example, if I have items 4 and 5 checked, I uncheck item 5, then check item 1: only item 1 will be checked, when it would be better to have items 1, 2, 3, 4 checked. 