### PR TITLE
fix slider position

### DIFF
--- a/27 - Click and Drag/style.css
+++ b/27 - Click and Drag/style.css
@@ -23,7 +23,6 @@ body {
   padding: 100px;
   width:100%;
   border:1px solid white;
-  box-shadow: 0 0 10px 7px rgba(0, 0, 0, 0.09);
   overflow-x: scroll;
   overflow-y: hidden;
   white-space: nowrap;


### PR DESCRIPTION
![screen](https://cloud.githubusercontent.com/assets/10504793/23626226/27bebe62-02bd-11e7-9174-e67d963bb5cc.png)

I don't know why it's happened (may be when we use box-shadow + overflow: scroll), but removing box-shadow (or setting overflow-x: **hidden** ) fixed it =)