### PR TITLE
typo fix in 03 - CSS variables

### DIFF
--- a/03 - CSS Variables/index-FINISHED.html
+++ b/03 - CSS Variables/index-FINISHED.html
@@ -43,9 +43,6 @@
 
     body {
       text-align: center;
-    }
-
-    body {
       background: #193549;
       color: white;
       font-family: 'helvetica neue', sans-serif;

--- a/03 - CSS Variables/index-START.html
+++ b/03 - CSS Variables/index-START.html
@@ -28,9 +28,6 @@
 
     body {
       text-align: center;
-    }
-
-    body {
       background: #193549;
       color: white;
       font-family: 'helvetica neue', sans-serif;


### PR DESCRIPTION
redundant CSS body selectors on lines 29/33 in START and FINISHED files

Consolidated into single selector.

Does not change the content of what's shown in the video, although the redundant body selectors are visible throughout the video as you revisit that part of the file.