### PR TITLE
Fix animation 'stick' bug

### DIFF
--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -59,8 +59,9 @@
 
 <script>
   function removeTransition(e) {
-    if (e.propertyName !== 'transform') return;
-    e.target.classList.remove('playing');
+		const key = document.querySelector(`.key[data-key="${e.which}"]`);
+		if(!key) return; 
+		key.classList.remove("playing");
   }
 
   function playSound(e) {
@@ -73,8 +74,7 @@
     audio.play();
   }
 
-  const keys = Array.from(document.querySelectorAll('.key'));
-  keys.forEach(key => key.addEventListener('transitionend', removeTransition));
+	window.addEventListener('keyup', removeTransition);
   window.addEventListener('keydown', playSound);
 </script>
 


### PR DESCRIPTION
In Chrome 58.0.3029, holding down one of the keys causes the animation to get 'stuck' and never reset with the current code (I recorded a gif if you'd like to see it).  That doesn't happen if you do it this way, listening for the keyup event (which is admittedly more vanilla and less interesting)

👋👋👋👋👋👋👋
👋👋👋👋👋👋👋
👋👋👋👋👋👋👋


