### PR TITLE
Changed to escaped double-quotes to fix browser-sync

### DIFF
--- a/19 - Webcam Fun/package.json
+++ b/19 - Webcam Fun/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "start" : "browser-sync start --server --files '*.css, *.html, *.js'"
+    "start": "browser-sync start --server --files \"*.css, *.html, *.js\""
   },
   "author": "",
   "license": "ISC",

--- a/20 - Speech Detection/package.json
+++ b/20 - Speech Detection/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "start" : "browser-sync start --directory --server --files '*.css, *.html, *.js'"
+    "start": "browser-sync start --directory --server --files \"*.css, *.html, *.js\""
   },
   "author": "",
   "license": "ISC",

--- a/21 - Geolocation/package.json
+++ b/21 - Geolocation/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "scripts.js",
   "scripts": {
-    "start" : "browser-sync start --directory --server --files '*.css, *.html, *.js' --https"
+    "start": "browser-sync start --directory --server --files \"*.css, *.html, *.js\" --https"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The 'files' argument was being passed to browser-sync inside single quotes. These aren't recognised when the script runs, so hot-reloading was only listening for changes on the html file.
Switching to escaped double quotes fixes this.