### PR TITLE
rm unused selector 'a'

### DIFF
--- a/06 - Type Ahead/style.css
+++ b/06 - Type Ahead/style.css
@@ -69,9 +69,3 @@
     .hl {
       background:#ffc600;
     }
-
-    a {
-      color:black;
-      background:rgba(0,0,0,0.1);
-      text-decoration: none;
-    }


### PR DESCRIPTION
Hi, Wes Bos
thank you very much for your free tutorials Javascript30
I love to see your Javascript30 project!

however, I might found a unused <a>selector In 06 - Type Ahead CSS.

thank you.




