### PR TITLE
Force browser-sync version less than 2.23.2 having issue in npm start

### DIFF
--- a/19 - Webcam Fun/package.json
+++ b/19 - Webcam Fun/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "browser-sync": "^2.12.5"
+    "browser-sync": "^2.12.5 <2.23.2"
   }
 }

--- a/20 - Speech Detection/package.json
+++ b/20 - Speech Detection/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "browser-sync": "^2.12.5"
+    "browser-sync": "^2.12.5 <2.23.2"
   }
 }

--- a/21 - Geolocation/package.json
+++ b/21 - Geolocation/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "browser-sync": "^2.12.5"
+    "browser-sync": "^2.12.5 <2.23.2"
   }
 }


### PR DESCRIPTION
browser-sync version 2.23.2 does not work in project 19, 20 or 21. In the browser just return "Cannot GET /index.html"

> $ npm list browser-sync
browser-sync@2.23.2

Version 2.23.1 of browser-sync works as expected.

Related issue https://github.com/BrowserSync/browser-sync/issues/1477

Simplest change seemed to be to limit the browser-sync version for now.
  
  