### PR TITLE
1/ the script requires the document to load in order to select the dom elements -> we use window.onload to run the script only when the document is loaded -> this way we can add the script tag to the head section instead of being forced to add it at the end of the body if we want it to work  there’s are in-depth explanations on this stack-overflow question page  https://stackoverflow.com/questions/15675745/javascript-code-not-work-in-head-tag  ////// we don't need to run forEach twice, we can just add all event listeners inside the callback function of the forEach method

### DIFF
--- a/03 - CSS Variables/index-FINISHED.html
+++ b/03 - CSS Variables/index-FINISHED.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>Scoped CSS Variables and JS</title>
 </head>
+
 <body>
   <h2>Update CSS Variables with <span class='hl'>JS</span></h2>
 
@@ -55,22 +57,27 @@
     }
 
     input {
-      width:100px;
+      width: 100px;
     }
   </style>
 
   <script>
-    const inputs = document.querySelectorAll('.controls input');
+    window.onload = function() {
 
-    function handleUpdate() {
-      const suffix = this.dataset.sizing || '';
-      document.documentElement.style.setProperty(`--${this.name}`, this.value + suffix);
+      const inputs = document.querySelectorAll('.controls input');
+
+      function handleUpdate() {
+        const suffix = this.dataset.sizing || '';
+        document.documentElement.style.setProperty(`--${this.name}`, this.value + suffix);
+      }
+
+      inputs.forEach(input => {
+        input.addEventListener('change', handleUpdate)
+        input.addEventListener('mousemove', handleUpdate)
+      });
     }
-
-    inputs.forEach(input => input.addEventListener('change', handleUpdate));
-    inputs.forEach(input => input.addEventListener('mousemove', handleUpdate));
   </script>
 
-
 </body>
+
 </html>


### PR DESCRIPTION
<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
