### PR TITLE
move regex out of the filter loop

### DIFF
--- a/06 - Type Ahead/index-FINISHED.html
+++ b/06 - Type Ahead/index-FINISHED.html
@@ -23,10 +23,12 @@ fetch(endpoint)
   .then(data => cities.push(...data));
 
 function findMatches(wordToMatch, cities) {
+  const regex = new RegExp(wordToMatch, 'gi');
+  
   return cities.filter(place => {
+    const { city, state } = place;
     // here we need to figure out if the city or state matches what was searched
-    const regex = new RegExp(wordToMatch, 'gi');
-    return place.city.match(regex) || place.state.match(regex)
+    return city.match(regex) || state.match(regex);
   });
 }
 


### PR DESCRIPTION
It's better to move `const regex = new RegExp(wordToMatch, 'gi');` out of the filter method, to prevent it was been reassigned every time it loop through the cities.

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
