### PR TITLE
Change how passes the localMediaStream to video

### DIFF
--- a/19 - Webcam Fun/scripts-FINISHED.js
+++ b/19 - Webcam Fun/scripts-FINISHED.js
@@ -8,7 +8,11 @@ function getVideo() {
   navigator.mediaDevices.getUserMedia({ video: true, audio: false })
     .then(localMediaStream => {
       console.log(localMediaStream);
-      video.src = window.URL.createObjectURL(localMediaStream);
+      /*
+        [Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68, around July 2018. Please use HTMLMediaElement.srcObject instead.
+        video.src = window.URL.createObjectURL(localMediaStream);
+      */ 
+      video.srcObject = localMediaStream;
       video.play();
     })
     .catch(err => {


### PR DESCRIPTION
[Deprecation] `URL.createObjectURL` with media streams is deprecated and will be removed in M68, around July 2018. Please use `HTMLMediaElement.srcObject` instead.
`video.src = window.URL.createObjectURL(localMediaStream);`
https://www.chromestatus.com/features/5618491470118912 or https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL