### PR TITLE
createObjectURL() has been depreceated.

### DIFF
--- a/19 - Webcam Fun/scripts-FINISHED.js
+++ b/19 - Webcam Fun/scripts-FINISHED.js
@@ -9,10 +9,12 @@ function getVideo() {
     .then(localMediaStream => {
       console.log(localMediaStream);
     
-//     DEPRECIATION : 
-//       The following has been depreceated by major browsers.
+//  DEPRECIATION : 
+//       The following has been depreceated by major browsers as of Chrome and Firefox.
 //       video.src = window.URL.createObjectURL(localMediaStream);
-//       Please refer to this:
+//       Please refer to these:
+//       Depreceated  - https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
+//       Newer Syntax - https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject
       
       video.srcObject = localMediaStream;
       video.play();

--- a/19 - Webcam Fun/scripts-FINISHED.js
+++ b/19 - Webcam Fun/scripts-FINISHED.js
@@ -8,7 +8,13 @@ function getVideo() {
   navigator.mediaDevices.getUserMedia({ video: true, audio: false })
     .then(localMediaStream => {
       console.log(localMediaStream);
-      video.src = window.URL.createObjectURL(localMediaStream);
+    
+//     DEPRECIATION : 
+//       The following has been depreceated by major browsers.
+//       video.src = window.URL.createObjectURL(localMediaStream);
+//       Please refer to this:
+      
+      video.srcObject = localMediaStream;
       video.play();
     })
     .catch(err => {


### PR DESCRIPTION
Replaced createObjectURL() with newer syntax. 
===================================
Well, if this PR is merged, it may be slightly different(only a single line) from the videos as createObjectURL() has been deprecated by major browsers. Just alerting @wesbos and others if not aware.

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
