### PR TITLE
Comment on mistakes in JS and CSS Clock video

### DIFF
--- a/02 - JS and CSS Clock/index-FINISHED.html
+++ b/02 - JS and CSS Clock/index-FINISHED.html
@@ -85,8 +85,8 @@
     const minsDegrees = ((mins / 60) * 360) + ((seconds/60)*6) + 90;
     minsHand.style.transform = `rotate(${minsDegrees}deg)`;
 
-    const hour = now.getHours();
-    const hourDegrees = ((hour / 12) * 360) + ((mins/60)*30) + 90;
+    const hour = now.getHours(); //Video accidentally uses getMinutes()
+    const hourDegrees = ((hour / 12) * 360) + ((mins/60)*30) + 90; //Video accidentally uses mins instead of hour
     hourHand.style.transform = `rotate(${hourDegrees}deg)`;
   }
 


### PR DESCRIPTION
Added comments noting a couple mistakes present in the video but not `index-FINISHED.html`. 
Tried to make the comments straightforward, but feel free to reword.

_These are **actual mistakes**, not different implementations._ Leaving comments in the code isn't an elegant way to address this, but I figure you'd wanna address it _somehow_.

Others previously pointed this out in YouTube comments. See [comment 1](https://www.youtube.com/watch?v=xu87YWbr4X0&lc=UgxMk4wJyp_sZI8qqy54AaABAg), [comment 2](https://www.youtube.com/watch?v=xu87YWbr4X0&lc=UgxU5-5S8_5VkhkkyBl4AaABAg).

Mistakes shown in the screenshot below.

![02 - css js clock mp4_snapshot_10 33_ 2019 01 29_15 25 07](https://user-images.githubusercontent.com/17228609/51938061-201b1800-23da-11e9-8888-1463f8673120.jpg)