### PR TITLE
added quotation marks to background in css of the day1 style.css

### DIFF
--- a/01 - JavaScript Drum Kit/style.css
+++ b/01 - JavaScript Drum Kit/style.css
@@ -1,6 +1,6 @@
 html {
   font-size: 10px;
-  background: url(http://i.imgur.com/b9r5sEL.jpg) bottom center;
+  background: url('http://i.imgur.com/b9r5sEL.jpg') bottom center;
   background-size: cover;
 }
 


### PR DESCRIPTION
Background image will now display. 01 - Javascript Drum Kit had missing quotation marks on the style.css file for "background"