### PR TITLE
Day2backgroundimg

### DIFF
--- a/02 - JS and CSS Clock/index-START.html
+++ b/02 - JS and CSS Clock/index-START.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>JS + CSS Clock</title>
 </head>
+
 <body>
 
 
-    <div class="clock">
-      <div class="clock-face">
-        <div class="hand hour-hand"></div>
-        <div class="hand min-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
+  <div class="clock">
+    <div class="clock-face">
+      <div class="hand hour-hand"></div>
+      <div class="hand min-hand"></div>
+      <div class="hand second-hand"></div>
     </div>
+  </div>
 
 
   <style>
     html {
-      background: #018DED url(http://unsplash.it/1500/1000?image=881&blur=50);
+      background: #018DED url(http://unsplash.it/1500/1000?image=881&blur=5);
       background-size: cover;
       font-family: 'helvetica neue';
       text-align: center;
@@ -43,17 +45,18 @@
       position: relative;
       padding: 2rem;
       box-shadow:
-        0 0 0 4px rgba(0,0,0,0.1),
+        0 0 0 4px rgba(0, 0, 0, 0.1),
         inset 0 0 0 3px #EFEFEF,
         inset 0 0 10px black,
-        0 0 10px rgba(0,0,0,0.2);
+        0 0 10px rgba(0, 0, 0, 0.2);
     }
 
     .clock-face {
       position: relative;
       width: 100%;
       height: 100%;
-      transform: translateY(-3px); /* account for the height of the clock hands */
+      transform: translateY(-3px);
+      /* account for the height of the clock hands */
     }
 
     .hand {
@@ -63,7 +66,6 @@
       position: absolute;
       top: 50%;
     }
-
   </style>
 
   <script>
@@ -71,4 +73,5 @@
 
   </script>
 </body>
+
 </html>

--- a/02 - JS and CSS Clock/index-START.html
+++ b/02 - JS and CSS Clock/index-START.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8">
   <title>JS + CSS Clock</title>
 </head>
-
 <body>
 
 
-  <div class="clock">
-    <div class="clock-face">
-      <div class="hand hour-hand"></div>
-      <div class="hand min-hand"></div>
-      <div class="hand second-hand"></div>
+    <div class="clock">
+      <div class="clock-face">
+        <div class="hand hour-hand"></div>
+        <div class="hand min-hand"></div>
+        <div class="hand second-hand"></div>
+      </div>
     </div>
-  </div>
 
 
   <style>
@@ -45,18 +43,17 @@
       position: relative;
       padding: 2rem;
       box-shadow:
-        0 0 0 4px rgba(0, 0, 0, 0.1),
+        0 0 0 4px rgba(0,0,0,0.1),
         inset 0 0 0 3px #EFEFEF,
         inset 0 0 10px black,
-        0 0 10px rgba(0, 0, 0, 0.2);
+        0 0 10px rgba(0,0,0,0.2);
     }
 
     .clock-face {
       position: relative;
       width: 100%;
       height: 100%;
-      transform: translateY(-3px);
-      /* account for the height of the clock hands */
+      transform: translateY(-3px); /* account for the height of the clock hands */
     }
 
     .hand {
@@ -66,6 +63,7 @@
       position: absolute;
       top: 50%;
     }
+
   </style>
 
   <script>
@@ -73,5 +71,4 @@
 
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
The background image url in '02 - JS & CSS Clock' returns "Invalid blur amount" in chrome, safari, and firefox. Removing the '0' from '50' in the url fixes this and allows the image to display.
![Screen Shot 2019-06-13 at 5 23 37 PM](https://user-images.githubusercontent.com/45956512/59471201-09f97b80-8e00-11e9-9fa8-303683065296.png)
![Screen Shot 2019-06-13 at 5 24 32 PM](https://user-images.githubusercontent.com/45956512/59471231-22699600-8e00-11e9-9f4e-f94ebfae056a.png)