### PR TITLE
[Day 19] Make request to snap.mp3 via HTTPS instead of HTTP

### DIFF
--- a/19 - Webcam Fun/index.html
+++ b/19 - Webcam Fun/index.html
@@ -37,7 +37,7 @@
     <div class="strip"></div>
   </div>
 
-  <audio class="snap" src="http://wesbos.com/demos/photobooth/snap.mp3" hidden></audio>
+  <audio class="snap" src="https://wesbos.com/demos/photobooth/snap.mp3" hidden></audio>
 
   <script src="scripts.js"></script>
 


### PR DESCRIPTION
The sound of `snap.mp3` used on day 19 when the user takes a photo is requested by the browser via HTTP.

This means that when this page is put on a server serving HTTPS, the browser will warn the user that connection is not totally secure like shown:

![snap](https://user-images.githubusercontent.com/6928620/62498446-1e8e3a80-b7d7-11e9-8d88-ccca0e41e732.png)

There's no need to use http since `wesbos.com` accepts HTTPS.
