### PR TITLE
Update the url of background image to https

### DIFF
--- a/01 - JavaScript Drum Kit/style.css
+++ b/01 - JavaScript Drum Kit/style.css
@@ -1,6 +1,6 @@
 html {
   font-size: 10px;
-  background: url(http://i.imgur.com/b9r5sEL.jpg) bottom center;
+  background: url(https://i.imgur.com/b9r5sEL.jpg) bottom center;
   background-size: cover;
 }
 


### PR DESCRIPTION
In order to avoid mixed content(https://www.cloudflare.com/learning/ssl/what-is-mixed-content/) error, we can update the URL from HTTP to HTTPS.
