### PR TITLE
Day 10: Fix for intial state bug on shift click of first element.

### DIFF
--- a/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
+++ b/10 - Hold Shift and Check Checkboxes/index-FINISHED.html
@@ -105,20 +105,24 @@ function handleCheck(e) {
   // Check if they had the shift key down
   // AND check that they are checking it
   let inBetween = false;
-  if (e.shiftKey && this.checked) {
-    // go ahead and do what we please
-    // loop over every single checkbox
-    checkboxes.forEach(checkbox => {
-      console.log(checkbox);
-      if (checkbox === this || checkbox === lastChecked) {
-        inBetween = !inBetween;
-        console.log('Starting to check them in between!');
-      }
+  // Make sure we're not doing an initial shift click
+  // or just clicking the same item again
+  if (lastChecked !== this && lastChecked !== undefined) {
+    if (e.shiftKey && this.checked) {
+      // go ahead and do what we please
+      // loop over every single checkbox
+      checkboxes.forEach(checkbox => {
+        console.log(checkbox);
+        if (checkbox === this || checkbox === lastChecked) {
+          inBetween = !inBetween;
+          console.log('Starting to check them in between!');
+        }
 
-      if (inBetween) {
-        checkbox.checked = true;
-      }
-    });
+        if (inBetween) {
+          checkbox.checked = true;
+        }
+      });
+    }
   }
 
   lastChecked = this;


### PR DESCRIPTION
<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->

Hey Wes,

There might be a bug in this solution...

To reproduce:
-  When you shift click an element of the page after a page refresh (initial state) it will select `all` elements below it.
- This behaviour also happens when you click an item, and then immediately shift click the same item.

My work around was just to check that a choice has not yet been made, and to look for cases where you shift click the same item that your previously selected.

This MIGHT actually be desired behaviour, so please let me know, but my suspicion is that it's not supposed to work this way.

Thanks for reading,

Niall
