### PR TITLE
Set the flex-basis for progress bar to 0%

### DIFF
--- a/11 - Custom Video Player/style.css
+++ b/11 - Custom Video Player/style.css
@@ -101,7 +101,7 @@ body {
   width: 50%;
   background: #ffc600;
   flex: 0;
-  flex-basis: 50%;
+  flex-basis: 0%;
 }
 
 /* unholy css to style input type="range" */


### PR DESCRIPTION
Issue:
The progress bar starts at 50% when it should start at 0%.

Solution:
Change the flex-basis to 0% for the progresss__filled css class.