### PR TITLE
11 Custom Video Player fix mouseup event

### DIFF
--- a/11 - Custom Video Player/scripts-FINISHED.js
+++ b/11 - Custom Video Player/scripts-FINISHED.js
@@ -52,4 +52,4 @@ let mousedown = false;
 progress.addEventListener('click', scrub);
 progress.addEventListener('mousemove', (e) => mousedown && scrub(e));
 progress.addEventListener('mousedown', () => mousedown = true);
-progress.addEventListener('mouseup', () => mousedown = false);
+document.addEventListener('mouseup', () => mousedown = false);


### PR DESCRIPTION
Make mouseup event on document instead of progress so that the mousedown flag will be reset even if the mouse is released somewhere other than the progress bar. As it stands now if you click drag on the progress bar, move off the bar and release, then mouse down is still activated and scrub will be called whenever the mouse runs over the progress bar.

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
