### PR TITLE
correct startX due to scale (0.98) applied to div

### DIFF
--- a/27 - Click and Drag/index-FINISHED.html
+++ b/27 - Click and Drag/index-FINISHED.html
@@ -43,7 +43,7 @@
   slider.addEventListener('mousedown', (e) => {
     isDown = true;
     slider.classList.add('active');
-    startX = e.pageX - slider.offsetLeft;
+    startX = e.pageX - slider.offsetLeft - slider.offsetWidth * 0.02 / 2;
     scrollLeft = slider.scrollLeft;
   });
 


### PR DESCRIPTION
<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->

Hi, because the slider div has `transform: scale (0.98)` applied to it, to get the correct startX position we have do subtract an additional amount equal to:
`slider.offsetWidth * 0.02 / 2` <!--take the 2% of the untransformed div width, divide by two because we are only looking at the left side -->


