### PR TITLE
remove unused class on returned <span>

### DIFF
--- a/06 - Type Ahead/index-FINISHED.html
+++ b/06 - Type Ahead/index-FINISHED.html
@@ -42,7 +42,7 @@ function displayMatches() {
     const stateName = place.state.replace(regex, `<span class="hl">${this.value}</span>`);
     return `
       <li>
-        <span class="name">${cityName}, ${stateName}</span>
+        <span>${cityName}, ${stateName}</span>
         <span class="population">${numberWithCommas(place.population)}</span>
       </li>
     `;


### PR DESCRIPTION
Remove the `name` class from the `<span>` element that holds the City and State names (from the `displayMatches` function) as that class is not being used at all.
