### PR TITLE
[03 - CSS Variables] #8 change class "hl" to "h1" as per video

### DIFF
--- a/03 - CSS Variables/index-START.html
+++ b/03 - CSS Variables/index-START.html
@@ -5,7 +5,7 @@
   <title>Scoped CSS Variables and JS</title>
 </head>
 <body>
-  <h2>Update CSS Variables with <span class='hl'>JS</span></h2>
+  <h2>Update CSS Variables with <span class='h1'>JS</span></h2>
 
   <div class="controls">
     <label for="spacing">Spacing:</label>


### PR DESCRIPTION
**EDIT:** Ok, after getting back to this I understand why it was changed to hl instead of useing h1 incorrectly, just wish there was an overlay for the tutorial videos which addressed this change.

Hey, in the video you had `h1` here instead of `hl` which we have here, should probably fix for less confusement. :)

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
