### PR TITLE
Fix Lesson"03 - CSS Variables" bug: not changing color immediately

### DIFF
--- a/03 - CSS Variables/index-FINISHED.html
+++ b/03 - CSS Variables/index-FINISHED.html
@@ -67,7 +67,7 @@
       document.documentElement.style.setProperty(`--${this.name}`, this.value + suffix);
     }
 
-    inputs.forEach(input => input.addEventListener('change', handleUpdate));
+    inputs.forEach(input => input.addEventListener('input', handleUpdate));
     inputs.forEach(input => input.addEventListener('mousemove', handleUpdate));
   </script>
 


### PR DESCRIPTION
Hi 
I have changed the event type: 'change' to 'input' in addEventListener(), which fixes the problem of not changing color immediately when clicked the colors input tag.


![color doesn't change onclick](https://user-images.githubusercontent.com/37059780/123219302-543d8900-d4ff-11eb-8c17-0c7b09c930fb.png)

