### PR TITLE
Fix Long Key Press Bug

### DIFF
--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -59,7 +59,7 @@
 
 <script>
   function removeTransition(e) {
-    if (e.propertyName !== 'transform') return;
+    if (e.target.classList[1] !== 'playing') return;
     e.target.classList.remove('playing');
   }
 

--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -59,7 +59,7 @@
 
 <script>
   function removeTransition(e) {
-    if (e.target.classList[1] !== 'playing') return;
+    if ( ! e.target.classList.contains('playing')) return;
     e.target.classList.remove('playing');
   }
 


### PR DESCRIPTION
The playing class is not being removed from the keys if they are held down for a long time. This happens because when it's held down for long, there's actually no transformation taking place and thus on line 61, the removeTransition function simply returns the controller without removing the 'playing' class. In this commit, I've updated line 61 such that if the target classList doesn't contain 'playing', the controller will be returned. Else, the 'playing' class will be removed.

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
