### PR TITLE
save video currenttime to local storage and get the time back when the page is reloaded also set video currenttime when you scrub the video.

### DIFF
--- a/11 - Custom Video Player/.vscode/settings.json
+++ b/11 - Custom Video Player/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/11 - Custom Video Player/index.html
+++ b/11 - Custom Video Player/index.html
@@ -22,6 +22,6 @@
      </div>
    </div>
 
-  <script src="scripts.js"></script>
+  <script src="scripts-FINISHED.js"></script>
 </body>
 </html>

--- a/11 - Custom Video Player/scripts-FINISHED.js
+++ b/11 - Custom Video Player/scripts-FINISHED.js
@@ -7,11 +7,21 @@ const toggle = player.querySelector('.toggle');
 const skipButtons = player.querySelectorAll('[data-skip]');
 const ranges = player.querySelectorAll('.player__slider');
 
+let currentVideoTime = localStorage.getItem('currentVideoTime') || 0;
+
 /* Build out functions */
 function togglePlay() {
   const method = video.paused ? 'play' : 'pause';
   video[method]();
+  currentVideoTime= video.currentTime;
+  localStorage.setItem('currentVideoTime', currentVideoTime);
 }
+
+window.addEventListener('DOMContentLoaded', (event) => {
+  localStorage.setItem('currentVideoTime', currentVideoTime);
+  currentVideoTime = parseFloat(localStorage.getItem('currentVideoTime')) || 0;
+  video.currentTime = currentVideoTime;
+});
 
 function updateButton() {
   const icon = this.paused ? '►' : '❚ ❚';
@@ -34,7 +44,10 @@ function handleProgress() {
 
 function scrub(e) {
   const scrubTime = (e.offsetX / progress.offsetWidth) * video.duration;
-  video.currentTime = scrubTime;
+  // video.currentTime = scrubTime;
+  localStorage.setItem('currentVideoTime', scrubTime);
+  currentVideoTime = parseFloat(localStorage.getItem('currentVideoTime')) || 0;
+  video.currentTime = currentVideoTime;
 }
 
 /* Hook up the event listeners */


### PR DESCRIPTION
## What I did
1: I created a variable using let called ```currentVideoTime```
like so
<img width="536" alt="Screenshot 2022-06-22 at 14 37 55" src="https://user-images.githubusercontent.com/50802773/175042871-2595404a-64db-4653-86a6-a5029db701e1.png">

2: I am setting the video current time to local storage every time the togglePlay function is being clicked, so local storage always has the correct current time after a pause and a play is triggered, like so

<img width="494" alt="Screenshot 2022-06-22 at 14 38 50" src="https://user-images.githubusercontent.com/50802773/175043336-0a97aad1-1924-4c7a-9cb6-ecce687354ef.png">

3: I created a DOMContentLoaded event listener so when the page is reloaded, it saves and gets the current time and passes it to the video player, so with this the currentTime state is tracked on the fly, like so
<img width="581" alt="Screenshot 2022-06-22 at 14 41 32" src="https://user-images.githubusercontent.com/50802773/175043975-9822b0c0-1042-4b97-b725-fd3ade50fe8c.png">

4: I also set the video.current time when the video is also scrubbed, the scrub time will now be the new current time, like so

<img width="582" alt="Screenshot 2022-06-22 at 14 45 41" src="https://user-images.githubusercontent.com/50802773/175044581-7bed3662-e2c7-41df-9863-60322ca873f3.png">
 