### PR TITLE
Make changes to `audio` and `div` to make script compatible with `event.code`

### DIFF
--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -8,54 +8,58 @@
 <body>
 
 
-  <div class="keys">
-    <div data-key="65" class="key">
-      <kbd>A</kbd>
-      <span class="sound">clap</span>
-    </div>
-    <div data-key="83" class="key">
-      <kbd>S</kbd>
-      <span class="sound">hihat</span>
-    </div>
-    <div data-key="68" class="key">
-      <kbd>D</kbd>
-      <span class="sound">kick</span>
-    </div>
-    <div data-key="70" class="key">
-      <kbd>F</kbd>
-      <span class="sound">openhat</span>
-    </div>
-    <div data-key="71" class="key">
-      <kbd>G</kbd>
-      <span class="sound">boom</span>
-    </div>
-    <div data-key="72" class="key">
-      <kbd>H</kbd>
-      <span class="sound">ride</span>
-    </div>
-    <div data-key="74" class="key">
-      <kbd>J</kbd>
-      <span class="sound">snare</span>
-    </div>
-    <div data-key="75" class="key">
-      <kbd>K</kbd>
-      <span class="sound">tom</span>
-    </div>
-    <div data-key="76" class="key">
-      <kbd>L</kbd>
-      <span class="sound">tink</span>
-    </div>
+<div class="keys">
+  <div data-key="KeyA" class="key">
+    <kbd>A</kbd>
+    <span class="sound">clap</span>
   </div>
+  <div data-key="KeyS" class="key">
+    <kbd>S</kbd>
+    <span class="sound">hihat</span>
+  </div>
+  <div data-key="KeyD" class="key">
+    <kbd>D</kbd>
+    <span class="sound">kick</span>
+  </div>
+  <div data-key="KeyF" class="key">
+    <kbd>F</kbd>
+    <span class="sound">openhat</span>
+  </div>
+  <div data-key="KeyG" class="key">
+    <kbd>G</kbd>
+    <span class="sound">boom</span>
+  </div>
+  <div data-key="KeyH" class="key">
+    <kbd>H</kbd>
+    <span class="sound">ride</span>
+  </div>
+  <div data-key="KeyJ" class="key">
+    <kbd>J</kbd>
+    <span class="sound">snare</span>
+  </div>
+  <div data-key="KeyK" class="key">
+    <kbd>K</kbd>
+    <span class="sound">tom</span>
+  </div>
+  <div data-key="KeyL" class="key">
+    <kbd>L</kbd>
+    <span class="sound">tink</span>
+  </div>
+</div>
 
-  <audio data-key="65" src="sounds/clap.wav"></audio>
-  <audio data-key="83" src="sounds/hihat.wav"></audio>
-  <audio data-key="68" src="sounds/kick.wav"></audio>
-  <audio data-key="70" src="sounds/openhat.wav"></audio>
-  <audio data-key="71" src="sounds/boom.wav"></audio>
-  <audio data-key="72" src="sounds/ride.wav"></audio>
-  <audio data-key="74" src="sounds/snare.wav"></audio>
-  <audio data-key="75" src="sounds/tom.wav"></audio>
-  <audio data-key="76" src="sounds/tink.wav"></audio>
+<audio data-key="KeyA" src="sounds/clap.wav"></audio>
+<audio data-key="KeyS" src="sounds/hihat.wav"></audio>
+<audio data-key="KeyD" src="sounds/kick.wav"></audio>
+<audio data-key="KeyF" src="sounds/openhat.wav"></audio>
+<audio data-key="KeyG" src="sounds/boom.wav"></audio>
+<audio data-key="KeyH" src="sounds/ride.wav"></audio>
+<audio data-key="KeyJ" src="sounds/snare.wav"></audio>
+<audio data-key="KeyK" src="sounds/tom.wav"></audio>
+<audio data-key="KeyL" src="sounds/tink.wav"></audio>
+
+<!--When writing script to capture keyboard code, do not use `keyCode` as it has been deprecated.-->
+<!--Use `code` to capture input instead.-->
+<!--The exercise has been modified to use `code` by changing data-key value.-->
 
 <script>
   function removeTransition(e) {
@@ -65,7 +69,7 @@
 
   function playSound(e) {
     const audio = document.querySelector(`audio[data-key="${e.keyCode}"]`);
-    const key = document.querySelector(`div[data-key="${e.keyCode}"]`);
+    const key = document.querySelector(`div[data-key="${e.code}"]`);
     if (!audio) return;
 
     key.classList.add('playing');

--- a/01 - JavaScript Drum Kit/index-START.html
+++ b/01 - JavaScript Drum Kit/index-START.html
@@ -8,54 +8,58 @@
 <body>
 
 
-  <div class="keys">
-    <div data-key="65" class="key">
-      <kbd>A</kbd>
-      <span class="sound">clap</span>
-    </div>
-    <div data-key="83" class="key">
-      <kbd>S</kbd>
-      <span class="sound">hihat</span>
-    </div>
-    <div data-key="68" class="key">
-      <kbd>D</kbd>
-      <span class="sound">kick</span>
-    </div>
-    <div data-key="70" class="key">
-      <kbd>F</kbd>
-      <span class="sound">openhat</span>
-    </div>
-    <div data-key="71" class="key">
-      <kbd>G</kbd>
-      <span class="sound">boom</span>
-    </div>
-    <div data-key="72" class="key">
-      <kbd>H</kbd>
-      <span class="sound">ride</span>
-    </div>
-    <div data-key="74" class="key">
-      <kbd>J</kbd>
-      <span class="sound">snare</span>
-    </div>
-    <div data-key="75" class="key">
-      <kbd>K</kbd>
-      <span class="sound">tom</span>
-    </div>
-    <div data-key="76" class="key">
-      <kbd>L</kbd>
-      <span class="sound">tink</span>
-    </div>
+<div class="keys">
+  <div data-key="KeyA" class="key">
+    <kbd>A</kbd>
+    <span class="sound">clap</span>
   </div>
+  <div data-key="KeyS" class="key">
+    <kbd>S</kbd>
+    <span class="sound">hihat</span>
+  </div>
+  <div data-key="KeyD" class="key">
+    <kbd>D</kbd>
+    <span class="sound">kick</span>
+  </div>
+  <div data-key="KeyF" class="key">
+    <kbd>F</kbd>
+    <span class="sound">openhat</span>
+  </div>
+  <div data-key="KeyG" class="key">
+    <kbd>G</kbd>
+    <span class="sound">boom</span>
+  </div>
+  <div data-key="KeyH" class="key">
+    <kbd>H</kbd>
+    <span class="sound">ride</span>
+  </div>
+  <div data-key="KeyJ" class="key">
+    <kbd>J</kbd>
+    <span class="sound">snare</span>
+  </div>
+  <div data-key="KeyK" class="key">
+    <kbd>K</kbd>
+    <span class="sound">tom</span>
+  </div>
+  <div data-key="KeyL" class="key">
+    <kbd>L</kbd>
+    <span class="sound">tink</span>
+  </div>
+</div>
 
-  <audio data-key="65" src="sounds/clap.wav"></audio>
-  <audio data-key="83" src="sounds/hihat.wav"></audio>
-  <audio data-key="68" src="sounds/kick.wav"></audio>
-  <audio data-key="70" src="sounds/openhat.wav"></audio>
-  <audio data-key="71" src="sounds/boom.wav"></audio>
-  <audio data-key="72" src="sounds/ride.wav"></audio>
-  <audio data-key="74" src="sounds/snare.wav"></audio>
-  <audio data-key="75" src="sounds/tom.wav"></audio>
-  <audio data-key="76" src="sounds/tink.wav"></audio>
+<audio data-key="KeyA" src="sounds/clap.wav"></audio>
+<audio data-key="KeyS" src="sounds/hihat.wav"></audio>
+<audio data-key="KeyD" src="sounds/kick.wav"></audio>
+<audio data-key="KeyF" src="sounds/openhat.wav"></audio>
+<audio data-key="KeyG" src="sounds/boom.wav"></audio>
+<audio data-key="KeyH" src="sounds/ride.wav"></audio>
+<audio data-key="KeyJ" src="sounds/snare.wav"></audio>
+<audio data-key="KeyK" src="sounds/tom.wav"></audio>
+<audio data-key="KeyL" src="sounds/tink.wav"></audio>
+
+<!--When writing script to capture keyboard code, do not use `keyCode` as it has been deprecated.-->
+<!--Use `code` to capture input instead.-->
+<!--The exercise has been modified to use `code` by changing data-key value.-->
 
 <script>
 


### PR DESCRIPTION
`event.keyCode` is deprecated and may be incompatible in future browser updates.
Additionally, I've found that using `event.keyCode` sometimes prevent sound from being played properly when pressed repeatedly (using macOS 12, Firefox 101), where the sound would not play if you repeatedly press the keystroke. `event.code` does not have such problem

<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
