### PR TITLE
sticky nav starting offset point issue on multiple screens is fixed by the height in px.

### DIFF
--- a/24 - Sticky Nav/style-FINISHED.css
+++ b/24 - Sticky Nav/style-FINISHED.css
@@ -31,7 +31,7 @@ body.fixed-nav .site-wrap {
 
 header {
   text-align: center;
-  height: 50vh;
+  height: 500px;
   background: url(https://source.unsplash.com/GKN6rpDr0EI/960x640) bottom center no-repeat;
   background-size: cover;
   display: flex;

--- a/24 - Sticky Nav/style-START.css
+++ b/24 - Sticky Nav/style-START.css
@@ -27,7 +27,7 @@ body {
 
 header {
   text-align: center;
-  height: 50vh;
+  height: 500px;
   background: url(https://source.unsplash.com/GKN6rpDr0EI/960x640) bottom center no-repeat;
   background-size: cover;
   display: flex;


### PR DESCRIPTION
The sticky nav starting offset point issue on multiple screens is fixed by the header height in px.










<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
