### PR TITLE
The color property using --base

### DIFF
--- a/03 - CSS Variables/index-FINISHED.html
+++ b/03 - CSS Variables/index-FINISHED.html
@@ -67,9 +67,9 @@
       const suffix = this.dataset.sizing || '';
       document.documentElement.style.setProperty(`--${this.name}`, this.value + suffix);
     }
-
-    inputs.forEach(input => input.addEventListener('change', handleUpdate));
-    inputs.forEach(input => input.addEventListener('mousemove', handleUpdate));
+    //the 'input' event listener can be a good substitue for 'change' and 'mouseover' listeners
+    inputs.forEach(input => input.addEventListener('input', handleUpdate));
+    
   </script>
 
 


### PR DESCRIPTION
I tried to change the color of the input element which changes the color of the <span class="hl">JS</span> and the background property of the img.The changes in the color palette didn't reflect immediately on the above mentioned elements but only when I closed the palette they reflected the changes.So instead of using two event listeners, 'change' and 'mouseover', I tried to achieve the functionality using just the 'input' event listener.

[03-CSS-variables_color.webm](https://user-images.githubusercontent.com/80001304/236501767-93891e25-c0d9-4993-a33b-2c101acdc94b.webm)


<!-- 
👋👋👋👋👋👋👋👋👋👋👋👋👋👋
👋👋👋Hello Friend!👋👋👋👋
👋👋👋👋👋👋👋👋👋👋👋👋👋👋

Thanks for Submitting a pull request. Before you hit that button please make sure:

These files are meant to be 1:1 copies of what is done in the video. If you found a better / different way to do things or fixed a small bug, that is great great, but I will be keeping them the same as the videos to avoid confusing. 

Spelling mistakes / CSS updates / other clarifications are welcome as long as they don't change what is shown in the videos. 

I encourage you to blog about your implementation and add the link to this repo - that way everyone can benefit from it.

-->
