### PR TITLE
Add drumkit audios overlap issue fix

### DIFF
--- a/01 - JavaScript Drum Kit/index-FINISHED.html
+++ b/01 - JavaScript Drum Kit/index-FINISHED.html
@@ -59,6 +59,9 @@
   <audio data-key="76" src="sounds/tink.wav"></audio>
 
 <script>
+
+  let currentAudio = null;
+
   function removeTransition(e) {
     if (e.propertyName !== 'transform') return;
     e.target.classList.remove('playing');
@@ -67,10 +70,16 @@
   function playSound(e) {
     const audio = document.querySelector(`audio[data-key="${e.keyCode}"]`);
     const key = document.querySelector(`div[data-key="${e.keyCode}"]`);
+
+    if(currentAudio && !currentAudio.paused){
+      currentAudio.pause();
+      currentAudio.currentTime = 0;
+    }
+
     if (!audio) return;
 
     key.classList.add('playing');
-    audio.currentTime = 0;
+    currentAudio = audio;
     audio.play();
   }
 


### PR DESCRIPTION
We might not observe the issue with the existing audio files as they're small in length, but if we replace and play any existing audio with a bit longer one(suggested>~2-3s) and play another audio before this ends - it's causing an overlapped playing of both the audios.

Hence I added a fix to check if there's an existing audio play and pause it in the affirmative