### PR TITLE
Fixed SpeechDetection 'end' event listener

### DIFF
--- a/20 - Speech Detection/index-FINISHED.html
+++ b/20 - Speech Detection/index-FINISHED.html
@@ -36,7 +36,7 @@
       }
   });
 
-  recognition.addEventListener('end', recognition.start);
+  recognition.addEventListener('end', () => recognition.start());
 
   recognition.start();
 


### PR DESCRIPTION
Passing only recognition.start in the event listener no longer works in Chrome due to an API update in 2025. This error is thrown:
Uncaught TypeError: Failed to execute 'start' on 'SpeechRecognition': parameter 1 is not of type 'MediaStreamTrack'.

Changing it to an arrow function fixes the issue.