### PR TITLE
fix: replace broken image URLs in flex panel gallery

### DIFF
--- a/05 - Flex Panel Gallery/index-FINISHED.html
+++ b/05 - Flex Panel Gallery/index-FINISHED.html
@@ -51,11 +51,11 @@
       flex-direction: column;
     }
 
-    .panel1 { background-image:url(https://source.unsplash.com/gYl-UtwNg_I/1500x1500); }
-    .panel2 { background-image:url(https://source.unsplash.com/rFKUFzjPYiQ/1500x1500); }
-    .panel3 { background-image:url(https://images.unsplash.com/photo-1465188162913-8fb5709d6d57?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&w=1500&h=1500&fit=crop&s=967e8a713a4e395260793fc8c802901d); }
-    .panel4 { background-image:url(https://source.unsplash.com/ITjiVXcwVng/1500x1500); }
-    .panel5 { background-image:url(https://source.unsplash.com/3MNzGlQM7qs/1500x1500); }
+    .panel1 { background-image: url(https://images.unsplash.com/photo-1443891238287-325a8fddd0f7?w=1500&h=1500); }
+    .panel2 { background-image: url(https://cdn.pixabay.com/photo/2017/08/07/16/48/green-2605621_1280.jpg); }
+    .panel3 { background-image: url(https://images.unsplash.com/photo-1465188162913-8fb5709d6d57?w=1500&h=1500); }
+    .panel4 { background-image: url(https://images.unsplash.com/photo-1442522772768-9032b6d10e3e?w=1500&h=1500); }
+    .panel5 { background-image: url(https://images.unsplash.com/photo-1465156799763-2c087c332922?w=1500&h=1500); }
 
     /* Flex Items */
     .panel > * {

--- a/05 - Flex Panel Gallery/index-START.html
+++ b/05 - Flex Panel Gallery/index-START.html
@@ -46,11 +46,11 @@
       background-position: center;
     }
 
-    .panel1 { background-image:url(https://source.unsplash.com/gYl-UtwNg_I/1500x1500); }
-    .panel2 { background-image:url(https://source.unsplash.com/rFKUFzjPYiQ/1500x1500); }
-    .panel3 { background-image:url(https://images.unsplash.com/photo-1465188162913-8fb5709d6d57?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&w=1500&h=1500&fit=crop&s=967e8a713a4e395260793fc8c802901d); }
-    .panel4 { background-image:url(https://source.unsplash.com/ITjiVXcwVng/1500x1500); }
-    .panel5 { background-image:url(https://source.unsplash.com/3MNzGlQM7qs/1500x1500); }
+    .panel1 { background-image: url(https://images.unsplash.com/photo-1443891238287-325a8fddd0f7?w=1500&h=1500); }
+    .panel2 { background-image: url(https://cdn.pixabay.com/photo/2017/08/07/16/48/green-2605621_1280.jpg); }
+    .panel3 { background-image: url(https://images.unsplash.com/photo-1465188162913-8fb5709d6d57?w=1500&h=1500); }
+    .panel4 { background-image: url(https://images.unsplash.com/photo-1442522772768-9032b6d10e3e?w=1500&h=1500); }
+    .panel5 { background-image: url(https://images.unsplash.com/photo-1465156799763-2c087c332922?w=1500&h=1500); }
 
     /* Flex Children */
     .panel > * {


### PR DESCRIPTION
Panel background images were broken due to discontinuation of the Unsplash Source API. Replaced with direct Unsplash image URLs and one Pixabay URL where the original image is no longer available. Images are the same as the original ones used. Code formatting has been maintained.